### PR TITLE
feat: simplify entry and add asconfig.json to extend

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 ## Example & Documentation
 
 ```ts
-const image: StaticArray<u8> = Inliner.inlineFileAsStaticArray("../images/hero.png");
+const image: StaticArray<u8> = Inliner.inlineFileAsStaticArray(
+  "../images/hero.png"
+);
 const welcomeText: string = Inline.inlineFileAsString("../README.md");
 
 export function main(): void {
@@ -20,11 +22,31 @@ It’s worth nothing that inlining a file as a string will assume that the file 
 `as-inliner` works through [ASC transforms][transforms]:
 
 ```
-$ npx asc -b your/output/path/file.wasm --transform ./node_modules/as-inliner/transform.js -O3
+$ npx asc -b your/output/path/file.wasm --transform as-inliner -O3
+```
+
+or place it in your `asconfig.json`:
+
+```json
+{
+  ...
+  "options": {
+    "transform": ["as-inliner"]
+  }
+}
+```
+
+Or extend the `asconfig.json` here:
+
+```json
+{
+  "extend": "as-inliner/asconfig.json"
+}
 ```
 
 ---
+
 License Apache-2.0
 
-[AssemblyScript]: https://www.assemblyscript.org/
+[assemblyscript]: https://www.assemblyscript.org/
 [transforms]: https://www.assemblyscript.org/transforms.html#transforms

--- a/asconfig.json
+++ b/asconfig.json
@@ -1,6 +1,6 @@
 {
   "options": {
-    "transform": ["./index.ts"]
+    "transform": ["./index.js"]
   }
 
 }

--- a/asconfig.json
+++ b/asconfig.json
@@ -1,0 +1,6 @@
+{
+  "options": {
+    "transform": ["./index.ts"]
+  }
+
+}

--- a/index.js
+++ b/index.js
@@ -13,9 +13,13 @@
 
 const fs = require("fs");
 const path = require("path");
-const { Transform } = require("assemblyscript/cli/transform");
-const assemblyscript = require("assemblyscript");
-const { Node, NodeKind, AssertionKind, ASTBuilder } = assemblyscript;
+const {
+  Node,
+  NodeKind,
+  AssertionKind,
+  ASTBuilder,
+  Transform,
+} = require("visitor-as/as");
 
 function* walk(maybeNode, visited = new WeakSet()) {
   if (!(maybeNode instanceof Node)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,27 +1,131 @@
 {
   "name": "as-inliner",
   "version": "0.0.2",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "0.0.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "visitor-as": "^0.4.0"
+      },
+      "devDependencies": {
+        "@types/node": "^14.14.35"
+      },
+      "peerDependencies": {
+        "assemblyscript": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "14.14.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
+      "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==",
+      "dev": true
+    },
+    "node_modules/assemblyscript": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.13.8.tgz",
+      "integrity": "sha512-HOwnJd/Fs88jPuQVA1Waz/njGJfu1tPQCL4hGas3XDvap6xVQUFGxx4hCxn8kFC8kSmVC3MBgFkWz+VPTes7Bw==",
+      "peer": true,
+      "dependencies": {
+        "binaryen": "93.0.0-nightly.20200609",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "asc": "bin/asc",
+        "asinit": "bin/asinit"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/assemblyscript"
+      }
+    },
+    "node_modules/binaryen": {
+      "version": "93.0.0-nightly.20200609",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-93.0.0-nightly.20200609.tgz",
+      "integrity": "sha512-CIaeav05u+fWRN2h1ecwIoSaOF/Mk6U85M/G6eg1nOHAXYYmOuh9TztF9Fu8krRWnl98J3W+VfDClApMV5zCtw==",
+      "peer": true,
+      "bin": {
+        "wasm-opt": "bin/wasm-opt"
+      }
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "peer": true
+    },
+    "node_modules/ts-mixer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-5.4.0.tgz",
+      "integrity": "sha512-Z5u/hpTkP4VWTIQT5vzxyeFAe8siPkatOC0Q49Uf56ccMGSHosI/IEo+t8BFvJX9yiF111YEOKfKY3m72V7F/w=="
+    },
+    "node_modules/visitor-as": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/visitor-as/-/visitor-as-0.4.0.tgz",
+      "integrity": "sha512-ey5It5E/CE7xl+PLaHaFqMIOZK8pLwM9m1lHjWZg8//afJ0acBde4aQbpT2+UnJdwPul6738cLYR/HM3Acz90w==",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "ts-mixer": "^5.1.0"
+      },
+      "peerDependencies": {
+        "assemblyscript": "^0.13.3"
+      }
+    }
+  },
   "dependencies": {
+    "@types/node": {
+      "version": "14.14.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
+      "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==",
+      "dev": true
+    },
     "assemblyscript": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.18.15.tgz",
-      "integrity": "sha512-s1N1qwdBhen2SLQApYCtRIPWm1Am3oAbW58GCEKbeN6ZbQRh7nq0pv4RDqKw6CgK7dySn/F2S1D6p0scyRbQRw==",
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.13.8.tgz",
+      "integrity": "sha512-HOwnJd/Fs88jPuQVA1Waz/njGJfu1tPQCL4hGas3XDvap6xVQUFGxx4hCxn8kFC8kSmVC3MBgFkWz+VPTes7Bw==",
+      "peer": true,
       "requires": {
-        "binaryen": "100.0.0",
+        "binaryen": "93.0.0-nightly.20200609",
         "long": "^4.0.0"
       }
     },
     "binaryen": {
-      "version": "100.0.0",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-100.0.0.tgz",
-      "integrity": "sha512-nxOt8d8/VXAuSVEtAWUdKrqpqCy365QqD223EzzB1GzS5himiZAfM/R5lXx+M/5q8TB8cYp3tYxv5rTjNTJveQ=="
+      "version": "93.0.0-nightly.20200609",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-93.0.0-nightly.20200609.tgz",
+      "integrity": "sha512-CIaeav05u+fWRN2h1ecwIoSaOF/Mk6U85M/G6eg1nOHAXYYmOuh9TztF9Fu8krRWnl98J3W+VfDClApMV5zCtw==",
+      "peer": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "peer": true
+    },
+    "ts-mixer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-5.4.0.tgz",
+      "integrity": "sha512-Z5u/hpTkP4VWTIQT5vzxyeFAe8siPkatOC0Q49Uf56ccMGSHosI/IEo+t8BFvJX9yiF111YEOKfKY3m72V7F/w=="
+    },
+    "visitor-as": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/visitor-as/-/visitor-as-0.4.0.tgz",
+      "integrity": "sha512-ey5It5E/CE7xl+PLaHaFqMIOZK8pLwM9m1lHjWZg8//afJ0acBde4aQbpT2+UnJdwPul6738cLYR/HM3Acz90w==",
+      "requires": {
+        "lodash.clonedeep": "^4.5.0",
+        "ts-mixer": "^5.1.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.2",
   "description": "Inlines files into your AssemblyScript",
   "types": "lib.ts",
-  "main": "transform.js",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/surma/as-inliner.git"
@@ -17,5 +17,11 @@
   "homepage": "https://github.com/surma/as-inliner#readme",
   "peerDependencies": {
     "assemblyscript": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^14.14.35"
+  },
+  "dependencies": {
+    "visitor-as": "^0.4.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "./node_modules/assemblyscript/std/assembly.json"
+  "extends": "assemblyscript/std/assembly.json",
+  "include": ["*.ts"]
 }


### PR DESCRIPTION
Didn't add any tests.  However, from experience you'll want to use the re-exported `assemblyscript` provided by `visitor-as` as it will look up the same module in cache.